### PR TITLE
Autoapprove

### DIFF
--- a/platform/bundles/org.eclipse.gyrex.cloud/src/org/eclipse/gyrex/cloud/internal/CloudState.java
+++ b/platform/bundles/org.eclipse.gyrex.cloud/src/org/eclipse/gyrex/cloud/internal/CloudState.java
@@ -93,7 +93,7 @@ public class CloudState implements ZooKeeperGateListener {
 		@Override
 		protected IStatus run(final IProgressMonitor monitor) {
 			try {
-				if (Boolean.TRUE.equals(System.getenv("gyrex.autoapprove")) || Boolean.TRUE.equals(System.getProperty("gyrex.autoapprove")) || getNodeEnvironment().inStandaloneMode()) {
+				if (Boolean.parseBoolean(System.getenv("gyrex.autoapprove")) || Boolean.parseBoolean(System.getProperty("gyrex.autoapprove")) || getNodeEnvironment().inStandaloneMode()) {
 					ZooKeeperNodeInfo.approve(nodeInfo.getNodeId(), null, nodeInfo.getLocation(), nodeInfo.getAddresses());
 					if (getNodeEnvironment().inStandaloneMode()) {
 						LOG.info("Node {} approved automatically. Welcome to your local cloud!", nodeInfo.getNodeId());
@@ -662,7 +662,7 @@ public class CloudState implements ZooKeeperGateListener {
 			try {
 				if (nodeInfo.isApproved()) {
 					setNodeOnline(nodeInfo);
-				} else if (Boolean.TRUE.equals(System.getenv("gyrex.autoapprove")) || Boolean.TRUE.equals(System.getProperty("gyrex.autoapprove")) || (Platform.inDevelopmentMode() && getNodeEnvironment().inStandaloneMode())) {
+				} else if (Boolean.parseBoolean(System.getenv("gyrex.autoapprove")) || Boolean.parseBoolean(System.getProperty("gyrex.autoapprove")) || (Platform.inDevelopmentMode() && getNodeEnvironment().inStandaloneMode())) {
 					// auto-approve in standalone mode or if the autoapprove option is set
 					// this needs to be async because approval triggers ZK events on which we react
 					LOG.info("Attempting automatic approval of node {} in standalong development system.", nodeInfo);

--- a/platform/bundles/org.eclipse.gyrex.cloud/src/org/eclipse/gyrex/cloud/internal/CloudState.java
+++ b/platform/bundles/org.eclipse.gyrex.cloud/src/org/eclipse/gyrex/cloud/internal/CloudState.java
@@ -95,11 +95,7 @@ public class CloudState implements ZooKeeperGateListener {
 			try {
 				if (Boolean.parseBoolean(System.getenv("gyrex.autoapprove")) || Boolean.parseBoolean(System.getProperty("gyrex.autoapprove")) || getNodeEnvironment().inStandaloneMode()) {
 					ZooKeeperNodeInfo.approve(nodeInfo.getNodeId(), null, nodeInfo.getLocation(), nodeInfo.getAddresses());
-					if (getNodeEnvironment().inStandaloneMode()) {
-						LOG.info("Node {} approved automatically. Welcome to your local cloud!", nodeInfo.getNodeId());
-					} else {
-						LOG.info("Node {} approved automatically. Because autoapprove was enabled.", nodeInfo.getNodeId());
-					}
+					LOG.info("Node {} approved automatically. Welcome to the cloud!", nodeInfo.getNodeId());
 				}
 				return Status.OK_STATUS;
 			} catch (final Exception e) {


### PR DESCRIPTION
Now the server looks for the option gyrex.autoapprove=true and tries a autoapprove like in the development mode. This is useful while operating in a docker environemt where you can simply scale the number of nodes.